### PR TITLE
Claim `surabaya.js`

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Our goal is to create a separate governance committee who can run this TLD. An e
 ## Claimed reserved domains
 1. blitz.js
 2. next.js
+3. surabaya.js
 
 ## Unclaimed reserved domains
 1. abbrev.js


### PR DESCRIPTION
Hi there! 👋🏻

I organize a local JavaScript user group called SurabayaJS (@surabayajs) and [based on this issue conversation](https://github.com/namebasehq/dotjs/issues/2#issuecomment-637978572), this PR claims the `surabaya.js` domain.